### PR TITLE
Use correct format for repository base URL

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -36,7 +36,7 @@ const config: DocsThemeConfig = {
       </>
     );
   },
-  docsRepositoryBase: "https://github.com/stampedeapp/api-docs",
+  docsRepositoryBase: "https://github.com/stampedeapp/api-docs/blob/main",
   useNextSeoProps: () => {
     return {
       titleTemplate: "%s – Let's Do This Public API Docs",


### PR DESCRIPTION
The 'edit this page' link was broken as we weren't using the correct URL format for files in GitHub