### PR TITLE
Update `page[size]` description to include max value of 500

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Welcome to the Let's Do This API
 
 Let's Do This spans a broad range of products that help you make incredible experiences for your participants.
 
-These docs will help you interact with the REST API to manage your events, communite with your particpants, export your start list data and much more!
+These docs will help you interact with the REST API to manage your events,
+communicate with your participants, export your start list data, and much more!
 
 ## Local Development
 

--- a/components/queryParams/pageSize.mdx
+++ b/components/queryParams/pageSize.mdx
@@ -5,5 +5,6 @@ import Parameter from '../../components/parameter';
   type='number'
   required={false}
 >
-  The number of results to return in a single response. Defaults to 100.
+  The number of results to be returned in a single response.
+  The value for page[size] can range from 1 to 500, with a default of 100.
 </Parameter>


### PR DESCRIPTION
Updates page[size] description to include max value of 500.

![image](https://github.com/stampedeapp/api-docs/assets/6449605/1aca46de-8e8b-4c08-8511-e7776ed6414e)
